### PR TITLE
Feat: 내 주문 내역 조회(회원/업주) API 구현

### DIFF
--- a/src/main/java/com/programmers/heycake/common/mapper/OrderMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/OrderMapper.java
@@ -114,15 +114,16 @@ public class OrderMapper {
 		List<MyOrderResponse> getOrderResponseList =
 				orderList
 						.stream()
-						.map(order -> new MyOrderResponse(
-								order.getId(),
-								order.getTitle(),
-								order.getOrderStatus(),
-								order.getRegion(),
-								order.getVisitDate(),
-								order.getCreatedAt(),
-								null
-						)).toList();
+						.map(order -> MyOrderResponse.builder()
+								.id(order.getId())
+								.title(order.getTitle())
+								.orderStatus(order.getOrderStatus())
+								.region(order.getRegion())
+								.visitTime(order.getVisitDate())
+								.createdAt(order.getCreatedAt())
+								.imageUrl(null)
+								.build()
+						).toList();
 		return new MyOrderResponseList(getOrderResponseList, lastTime);
 	}
 

--- a/src/main/java/com/programmers/heycake/common/mapper/OrderMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/OrderMapper.java
@@ -4,14 +4,20 @@ import static com.programmers.heycake.common.util.AuthenticationUtil.*;
 import static com.programmers.heycake.domain.order.model.vo.OrderStatus.*;
 import static lombok.AccessLevel.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import com.programmers.heycake.domain.image.model.dto.ImageResponse;
 import com.programmers.heycake.domain.image.model.dto.ImageResponses;
 import com.programmers.heycake.domain.member.model.dto.response.OrderGetDetailResponse;
 import com.programmers.heycake.domain.order.model.dto.OrderDto;
 import com.programmers.heycake.domain.order.model.dto.request.OrderCreateRequest;
+import com.programmers.heycake.domain.order.model.dto.response.MyOrderResponse;
+import com.programmers.heycake.domain.order.model.dto.response.MyOrderResponseList;
 import com.programmers.heycake.domain.order.model.dto.response.OrderGetDetailServiceResponse;
 import com.programmers.heycake.domain.order.model.entity.CakeInfo;
 import com.programmers.heycake.domain.order.model.entity.Order;
+import com.programmers.heycake.domain.order.model.entity.OrderHistory;
 
 import lombok.NoArgsConstructor;
 
@@ -93,5 +99,45 @@ public class OrderMapper {
 				.createdAt(orderGetDetailServiceResponse.createdAt())
 				.updatedAt(orderGetDetailServiceResponse.updatedAt())
 				.build();
+	}
+
+	public static MyOrderResponseList toMyOrderResponseListForMember(
+			List<MyOrderResponse> orderList,
+			LocalDateTime lastTime) {
+		return new MyOrderResponseList(orderList, lastTime);
+	}
+
+	//TODO 추후에 삭제
+	public static MyOrderResponseList toMyOrderResponseListForMember(
+			LocalDateTime lastTime,
+			List<Order> orderList) {
+		List<MyOrderResponse> getOrderResponseList =
+				orderList
+						.stream()
+						.map(order -> new MyOrderResponse(
+								order.getId(),
+								order.getTitle(),
+								order.getOrderStatus(),
+								order.getRegion(),
+								order.getVisitDate(),
+								order.getCreatedAt(),
+								null
+						)).toList();
+		return new MyOrderResponseList(getOrderResponseList, lastTime);
+	}
+
+	public static MyOrderResponseList toGetOrderResponseListForMarket(
+			//TOO 나중에 수정
+			List<OrderHistory> orderHistoryList,
+			LocalDateTime lastTime
+	) {
+		List<Order> orderList =
+				orderHistoryList
+						.stream()
+						.map(OrderHistory::getOrder)
+						.toList();
+
+		//TODO 추후에 변경
+		return toMyOrderResponseListForMember(lastTime, orderList);
 	}
 }

--- a/src/main/java/com/programmers/heycake/domain/member/service/MemberService.java
+++ b/src/main/java/com/programmers/heycake/domain/member/service/MemberService.java
@@ -202,5 +202,10 @@ public class MemberService {
 						() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND)
 				);
 	}
+
+	@Transactional(readOnly = true)
+	public boolean isMarketById(Long memberId) {
+		return getMemberById(memberId).isMarket();
+	}
 }
 

--- a/src/main/java/com/programmers/heycake/domain/order/controller/OrderController.java
+++ b/src/main/java/com/programmers/heycake/domain/order/controller/OrderController.java
@@ -10,12 +10,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.programmers.heycake.domain.member.model.dto.response.OrderGetDetailResponse;
 import com.programmers.heycake.domain.order.facade.OrderFacade;
+import com.programmers.heycake.domain.order.model.dto.request.MyOrderRequest;
 import com.programmers.heycake.domain.order.model.dto.request.OrderCreateRequest;
+import com.programmers.heycake.domain.order.model.dto.response.MyOrderResponseList;
 
 import lombok.RequiredArgsConstructor;
 
@@ -39,5 +42,12 @@ public class OrderController {
 	@GetMapping("/{orderId}")
 	public ResponseEntity<OrderGetDetailResponse> getOrder(@PathVariable Long orderId) {
 		return ResponseEntity.ok(orderFacade.getOrder(orderId));
+	}
+
+	@GetMapping("/my")
+	public ResponseEntity<MyOrderResponseList> getOrderList(@RequestBody @Valid MyOrderRequest getOrderRequest) {
+		MyOrderResponseList myOrderList = orderFacade.getMyOrderList(getOrderRequest);
+
+		return ResponseEntity.ok(myOrderList);
 	}
 }

--- a/src/main/java/com/programmers/heycake/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/order/facade/OrderFacade.java
@@ -1,6 +1,7 @@
 package com.programmers.heycake.domain.order.facade;
 
 import static com.programmers.heycake.common.mapper.OrderMapper.*;
+import static com.programmers.heycake.common.util.AuthenticationUtil.*;
 import static com.programmers.heycake.domain.image.model.vo.ImageType.*;
 
 import org.springframework.stereotype.Component;
@@ -10,8 +11,12 @@ import com.programmers.heycake.domain.image.model.dto.ImageResponses;
 import com.programmers.heycake.domain.image.service.ImageIntegrationService;
 import com.programmers.heycake.domain.image.service.ImageService;
 import com.programmers.heycake.domain.member.model.dto.response.OrderGetDetailResponse;
+import com.programmers.heycake.domain.member.service.MemberService;
+import com.programmers.heycake.domain.order.model.dto.request.MyOrderRequest;
 import com.programmers.heycake.domain.order.model.dto.request.OrderCreateRequest;
+import com.programmers.heycake.domain.order.model.dto.response.MyOrderResponseList;
 import com.programmers.heycake.domain.order.model.dto.response.OrderGetDetailServiceResponse;
+import com.programmers.heycake.domain.order.service.HistoryService;
 import com.programmers.heycake.domain.order.service.OrderService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,10 +24,13 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class OrderFacade {
-	private static final String ORDER_IMAGE_SUB_PATH = "images/orders";
 	private final OrderService orderService;
-	private final ImageIntegrationService imageIntegrationService;
+	private final MemberService memberService;
+	private final HistoryService historyService;
 	private final ImageService imageService;
+	private final ImageIntegrationService imageIntegrationService;
+
+	private static final String ORDER_IMAGE_SUB_PATH = "images/orders";
 
 	@Transactional
 	public Long createOrder(OrderCreateRequest orderCreateRequest) {
@@ -45,5 +53,15 @@ public class OrderFacade {
 		OrderGetDetailServiceResponse orderGetDetailServiceResponse = orderService.getOrderDetail(orderId);
 		ImageResponses imageResponses = imageService.getImages(orderGetDetailServiceResponse.orderId(), ORDER);
 		return toOrderGetDetailResponse(orderGetDetailServiceResponse, imageResponses);
+	}
+
+	@Transactional
+	public MyOrderResponseList getMyOrderList(MyOrderRequest getOrderRequest) {
+		Long memberId = getMemberId();
+		if (memberService.isMarketById(memberId)) {
+			return historyService.getMyOrderList(getOrderRequest, memberId);
+		} else {
+			return orderService.getMyOrderList(getOrderRequest, memberId);
+		}
 	}
 }

--- a/src/main/java/com/programmers/heycake/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/order/facade/OrderFacade.java
@@ -55,7 +55,7 @@ public class OrderFacade {
 		return toOrderGetDetailResponse(orderGetDetailServiceResponse, imageResponses);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public MyOrderResponseList getMyOrderList(MyOrderRequest getOrderRequest) {
 		Long memberId = getMemberId();
 		if (memberService.isMarketById(memberId)) {

--- a/src/main/java/com/programmers/heycake/domain/order/model/dto/request/MyOrderRequest.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/dto/request/MyOrderRequest.java
@@ -1,0 +1,20 @@
+package com.programmers.heycake.domain.order.model.dto.request;
+
+import java.time.LocalDateTime;
+
+import javax.validation.constraints.Positive;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.programmers.heycake.common.validator.Enum;
+import com.programmers.heycake.domain.order.model.vo.OrderStatus;
+
+public record MyOrderRequest(
+		@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+		LocalDateTime cursorTime,
+		@Positive
+		int pageSize,
+		@Enum(target = OrderStatus.class)
+		String orderStatus
+) {
+}

--- a/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponse.java
@@ -1,0 +1,22 @@
+package com.programmers.heycake.domain.order.model.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.programmers.heycake.domain.order.model.vo.OrderStatus;
+
+import lombok.Builder;
+
+@Builder
+public record MyOrderResponse(
+		Long id,
+		String title,
+		OrderStatus orderStatus,
+		String region,
+		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+		LocalDateTime visitTime,
+		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+		LocalDateTime createdAt,
+		String imageUrl
+) {
+}

--- a/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponseList.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponseList.java
@@ -1,0 +1,15 @@
+package com.programmers.heycake.domain.order.model.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public record MyOrderResponseList(
+		//TODO 나중에 변경
+		List<MyOrderResponse> myOrderResponseList,
+		// List<OrderDtoWithImage> myOrderResponseList,
+		@JsonFormat(pattern = "yyyy-MM-ddTHH:mm:ss", timezone = "Asia/Seoul")
+		LocalDateTime lastTime
+) {
+}

--- a/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponseList.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponseList.java
@@ -8,8 +8,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 public record MyOrderResponseList(
 		//TODO 나중에 변경
 		List<MyOrderResponse> myOrderResponseList,
-		// List<OrderDtoWithImage> myOrderResponseList,
 		@JsonFormat(pattern = "yyyy-MM-ddTHH:mm:ss", timezone = "Asia/Seoul")
-		LocalDateTime lastTime
+		LocalDateTime lastCursorTime
 ) {
 }

--- a/src/main/java/com/programmers/heycake/domain/order/repository/HistoryQueryDslRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/order/repository/HistoryQueryDslRepository.java
@@ -1,0 +1,47 @@
+package com.programmers.heycake.domain.order.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.programmers.heycake.domain.order.model.entity.OrderHistory;
+import com.programmers.heycake.domain.order.model.entity.QOrderHistory;
+import com.programmers.heycake.domain.order.model.vo.OrderStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class HistoryQueryDslRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	QOrderHistory qOrderHistory = QOrderHistory.orderHistory;
+
+	public List<OrderHistory> findAllByMarketIdOrderByVisitDateAsc(
+			Long memberId,
+			String option,
+			LocalDateTime cursorTime,
+			int pageSize) {
+		return jpaQueryFactory
+				.selectFrom(qOrderHistory)
+				.where(
+						gtOrderTime(cursorTime),
+						orderStatus(option),
+						qOrderHistory.marketId.eq(memberId)
+				).orderBy(qOrderHistory.order.visitDate.asc())
+				.limit(pageSize)
+				.fetch();
+
+	}
+
+	private BooleanExpression gtOrderTime(LocalDateTime cursorTime) {
+		return cursorTime == null ? null : qOrderHistory.order.visitDate.gt(cursorTime);
+	}
+
+	private BooleanExpression orderStatus(String option) {
+		return option == null ? null : qOrderHistory.order.orderStatus.eq(OrderStatus.valueOf(option));
+	}
+}

--- a/src/main/java/com/programmers/heycake/domain/order/repository/HistoryQueryDslRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/order/repository/HistoryQueryDslRepository.java
@@ -29,7 +29,7 @@ public class HistoryQueryDslRepository {
 				.selectFrom(qOrderHistory)
 				.where(
 						gtOrderTime(cursorTime),
-						orderStatus(option),
+						eqOrderStatus(option),
 						qOrderHistory.marketId.eq(memberId)
 				).orderBy(qOrderHistory.order.visitDate.asc())
 				.limit(pageSize)
@@ -41,7 +41,7 @@ public class HistoryQueryDslRepository {
 		return cursorTime == null ? null : qOrderHistory.order.visitDate.gt(cursorTime);
 	}
 
-	private BooleanExpression orderStatus(String option) {
+	private BooleanExpression eqOrderStatus(String option) {
 		return option == null ? null : qOrderHistory.order.orderStatus.eq(OrderStatus.valueOf(option));
 	}
 }

--- a/src/main/java/com/programmers/heycake/domain/order/repository/OrderQueryDslRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/order/repository/OrderQueryDslRepository.java
@@ -1,0 +1,143 @@
+package com.programmers.heycake.domain.order.repository;
+
+import static com.programmers.heycake.domain.image.model.vo.ImageType.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.programmers.heycake.domain.image.model.entity.QImage;
+import com.programmers.heycake.domain.order.model.dto.response.MyOrderResponse;
+import com.programmers.heycake.domain.order.model.entity.QOrder;
+import com.programmers.heycake.domain.order.model.vo.OrderStatus;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryDslRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+	QOrder qOrder = QOrder.order;
+	QImage qImage = QImage.image;
+
+	// public List<Order> findAllByMemberIdOrderByVisitDateAsc(Long memberId, String option, LocalDateTime cursorTime,
+	// 		int pageSize) {
+	// 	return jpaQueryFactory
+	// 			.selectFrom(qOrder)
+	// 			.where(
+	// 					gtOrderTime(cursorTime),
+	// 					orderStatus(option),
+	// 					qOrder.memberId.eq(memberId)
+	// 			).orderBy(qOrder.visitDate.asc())
+	// 			.limit(pageSize)
+	// 			.fetch();
+	// }
+
+	public List<MyOrderResponse> findAllByMemberIdOrderByVisitDateAsc(Long memberId, String option,
+			LocalDateTime cursorTime,
+			int pageSize) {
+
+		// List<String> imageUrls = jpaQueryFactory.selectFrom(qImage)
+		// 		.where(
+		// 				qImage.referenceId.eq(qOrder.id),
+		// 				qImage.imageType.eq(ORDER)
+		// 		).stream()
+		// 		.map(Image::getImageUrl)
+		// 		.toList();
+
+		return jpaQueryFactory
+				.select(
+						Projections.constructor(
+								MyOrderResponse.class,
+								qOrder.id,
+								qOrder.title,
+								qOrder.orderStatus,
+								qOrder.region,
+								qOrder.visitDate,
+								qOrder.createdAt,
+								qImage.imageUrl
+						)
+				)
+				.from(qOrder)
+				.leftJoin(qImage)
+				.on(
+						qOrder.id.eq(qImage.referenceId).and(qImage.imageType.eq(ORDER))
+				).limit(1)
+				.where(
+						gtOrderTime(cursorTime),
+						orderStatus(option),
+						qOrder.memberId.eq(memberId)
+				).orderBy(qOrder.visitDate.asc())
+				.limit(pageSize)
+				.fetch();
+
+		// List<Tuple> tuples = jpaQueryFactory
+		// 		.select(qOrder, qImage.imageUrl)
+		// 		.from(qOrder)
+		// 		.leftJoin(qImage)
+		// 		.on(qOrder.id.eq(qImage.referenceId),
+		// 				qImage.imageType.eq(ORDER))
+		// 		.select(qOrder, qImage.imageUrl)
+		// 		.from(qOrder)
+		// 		.where(
+		// 				qOrder.id.eq(memberId),
+		// 				gtOrderTime(cursorTime),
+		// 				orderStatus(option)
+		// 		).orderBy(qOrder.visitDate.asc())
+		// 		.limit(pageSize)
+		// 		.fetch();
+		//
+		// return tuples.stream()
+		// 		.distinct()
+		// 		.map(
+		// 				tuple -> MyOrderResponse.builder()
+		// 						.id(tuple.get(qOrder.id))
+		// 						.title(tuple.get(qOrder.title))
+		// 						.orderStatus(tuple.get(qOrder.orderStatus))
+		// 						.region(tuple.get(qOrder.region))
+		// 						.visitTime(tuple.get(qOrder.visitDate))
+		// 						.createdAt(tuple.get(qOrder.createdAt))
+		// 						.imageUrl(tuple.get(qImage.imageUrl))
+		// 						.build()
+		// 		).toList();
+
+		//TODO 리팩토링하기
+		// jpaQueryFactory.selectDistinct(qOrder, qImage.imageUrl)
+		// 		.from(qOrder)
+		// 		.leftJoin(
+		// 				select(qImage.referenceId, qImage.imageUrl)
+		// 						.from(qImage)
+		// 						.where(qImage.imageType.eq(ORDER))
+		// 						.groupBy(qImage.referenceId, qImage.imageUrl)
+		// 						.limit(1), qImage)
+		// 		.on(qOrder.id.eq(qImage.referenceId))
+		// 		.fetch();
+
+		// return jpaQueryFactory
+		// 		.select(qOrder, qImage.imageUrl)
+		// 		.from(qOrder)
+		// 		.leftJoin(
+		// 				JPAExpressions
+		// 						.select(qImage.referenceId, qImage.imageUrl)
+		// 						.from(qImage)
+		// 						.where(qImage.imageType.eq(ORDER))
+		// 						.groupBy(qImage.referenceId, qImage.imageUrl)
+		// 						.limit(1),
+		// 				on(qOrder.id.eq(qImage.referenceId))
+		// 		)
+		// 		.where(qOrder.id.eq(1L))
+		// 		.fetch();
+	}
+
+	private BooleanExpression gtOrderTime(LocalDateTime cursorTime) {
+		return cursorTime == null ? null : qOrder.visitDate.gt(cursorTime);
+	}
+
+	private BooleanExpression orderStatus(String option) {
+		return option == null ? null : qOrder.orderStatus.eq(OrderStatus.valueOf(option));
+	}
+}

--- a/src/main/java/com/programmers/heycake/domain/order/repository/OrderQueryDslRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/order/repository/OrderQueryDslRepository.java
@@ -24,30 +24,9 @@ public class OrderQueryDslRepository {
 	QOrder qOrder = QOrder.order;
 	QImage qImage = QImage.image;
 
-	// public List<Order> findAllByMemberIdOrderByVisitDateAsc(Long memberId, String option, LocalDateTime cursorTime,
-	// 		int pageSize) {
-	// 	return jpaQueryFactory
-	// 			.selectFrom(qOrder)
-	// 			.where(
-	// 					gtOrderTime(cursorTime),
-	// 					orderStatus(option),
-	// 					qOrder.memberId.eq(memberId)
-	// 			).orderBy(qOrder.visitDate.asc())
-	// 			.limit(pageSize)
-	// 			.fetch();
-	// }
-
 	public List<MyOrderResponse> findAllByMemberIdOrderByVisitDateAsc(Long memberId, String option,
 			LocalDateTime cursorTime,
 			int pageSize) {
-
-		// List<String> imageUrls = jpaQueryFactory.selectFrom(qImage)
-		// 		.where(
-		// 				qImage.referenceId.eq(qOrder.id),
-		// 				qImage.imageType.eq(ORDER)
-		// 		).stream()
-		// 		.map(Image::getImageUrl)
-		// 		.toList();
 
 		return jpaQueryFactory
 				.select(
@@ -69,75 +48,18 @@ public class OrderQueryDslRepository {
 				).limit(1)
 				.where(
 						gtOrderTime(cursorTime),
-						orderStatus(option),
+						eqOrderStatus(option),
 						qOrder.memberId.eq(memberId)
 				).orderBy(qOrder.visitDate.asc())
 				.limit(pageSize)
 				.fetch();
-
-		// List<Tuple> tuples = jpaQueryFactory
-		// 		.select(qOrder, qImage.imageUrl)
-		// 		.from(qOrder)
-		// 		.leftJoin(qImage)
-		// 		.on(qOrder.id.eq(qImage.referenceId),
-		// 				qImage.imageType.eq(ORDER))
-		// 		.select(qOrder, qImage.imageUrl)
-		// 		.from(qOrder)
-		// 		.where(
-		// 				qOrder.id.eq(memberId),
-		// 				gtOrderTime(cursorTime),
-		// 				orderStatus(option)
-		// 		).orderBy(qOrder.visitDate.asc())
-		// 		.limit(pageSize)
-		// 		.fetch();
-		//
-		// return tuples.stream()
-		// 		.distinct()
-		// 		.map(
-		// 				tuple -> MyOrderResponse.builder()
-		// 						.id(tuple.get(qOrder.id))
-		// 						.title(tuple.get(qOrder.title))
-		// 						.orderStatus(tuple.get(qOrder.orderStatus))
-		// 						.region(tuple.get(qOrder.region))
-		// 						.visitTime(tuple.get(qOrder.visitDate))
-		// 						.createdAt(tuple.get(qOrder.createdAt))
-		// 						.imageUrl(tuple.get(qImage.imageUrl))
-		// 						.build()
-		// 		).toList();
-
-		//TODO 리팩토링하기
-		// jpaQueryFactory.selectDistinct(qOrder, qImage.imageUrl)
-		// 		.from(qOrder)
-		// 		.leftJoin(
-		// 				select(qImage.referenceId, qImage.imageUrl)
-		// 						.from(qImage)
-		// 						.where(qImage.imageType.eq(ORDER))
-		// 						.groupBy(qImage.referenceId, qImage.imageUrl)
-		// 						.limit(1), qImage)
-		// 		.on(qOrder.id.eq(qImage.referenceId))
-		// 		.fetch();
-
-		// return jpaQueryFactory
-		// 		.select(qOrder, qImage.imageUrl)
-		// 		.from(qOrder)
-		// 		.leftJoin(
-		// 				JPAExpressions
-		// 						.select(qImage.referenceId, qImage.imageUrl)
-		// 						.from(qImage)
-		// 						.where(qImage.imageType.eq(ORDER))
-		// 						.groupBy(qImage.referenceId, qImage.imageUrl)
-		// 						.limit(1),
-		// 				on(qOrder.id.eq(qImage.referenceId))
-		// 		)
-		// 		.where(qOrder.id.eq(1L))
-		// 		.fetch();
 	}
 
 	private BooleanExpression gtOrderTime(LocalDateTime cursorTime) {
 		return cursorTime == null ? null : qOrder.visitDate.gt(cursorTime);
 	}
 
-	private BooleanExpression orderStatus(String option) {
+	private BooleanExpression eqOrderStatus(String option) {
 		return option == null ? null : qOrder.orderStatus.eq(OrderStatus.valueOf(option));
 	}
 }

--- a/src/main/java/com/programmers/heycake/domain/order/service/HistoryService.java
+++ b/src/main/java/com/programmers/heycake/domain/order/service/HistoryService.java
@@ -40,7 +40,7 @@ public class HistoryService {
 		);
 
 		LocalDateTime lastTime =
-				orderHistories.size() == 0 ? LocalDateTime.MAX :
+				orderHistories.isEmpty() ? LocalDateTime.MAX :
 						orderHistories.get(orderHistories.size() - 1).getOrder().getVisitDate();
 
 		return toGetOrderResponseListForMarket(orderHistories, lastTime);

--- a/src/main/java/com/programmers/heycake/domain/order/service/HistoryService.java
+++ b/src/main/java/com/programmers/heycake/domain/order/service/HistoryService.java
@@ -1,11 +1,19 @@
 package com.programmers.heycake.domain.order.service;
 
 import static com.programmers.heycake.common.mapper.HistoryMapper.*;
+import static com.programmers.heycake.common.mapper.OrderMapper.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.heycake.domain.order.model.dto.request.HistoryFacadeRequest;
+import com.programmers.heycake.domain.order.model.dto.request.MyOrderRequest;
+import com.programmers.heycake.domain.order.model.dto.response.MyOrderResponseList;
 import com.programmers.heycake.domain.order.model.entity.OrderHistory;
+import com.programmers.heycake.domain.order.repository.HistoryQueryDslRepository;
 import com.programmers.heycake.domain.order.repository.HistoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -14,9 +22,27 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class HistoryService {
 	private final HistoryRepository historyRepository;
+	private final HistoryQueryDslRepository historyQueryDslRepository;
 
+	@Transactional
 	public Long createHistory(HistoryFacadeRequest historyFacadeRequest) {
 		OrderHistory orderHistory = toOrderHistory(historyFacadeRequest);
 		return historyRepository.save(orderHistory).getId();
+	}
+
+	@Transactional(readOnly = true)
+	public MyOrderResponseList getMyOrderList(MyOrderRequest getOrderRequest, Long marketId) {
+		List<OrderHistory> orderHistories = historyQueryDslRepository.findAllByMarketIdOrderByVisitDateAsc(
+				marketId,
+				getOrderRequest.orderStatus(),
+				getOrderRequest.cursorTime(),
+				getOrderRequest.pageSize()
+		);
+
+		LocalDateTime lastTime =
+				orderHistories.size() == 0 ? LocalDateTime.MAX :
+						orderHistories.get(orderHistories.size() - 1).getOrder().getVisitDate();
+
+		return toGetOrderResponseListForMarket(orderHistories, lastTime);
 	}
 }

--- a/src/main/java/com/programmers/heycake/domain/order/service/OrderService.java
+++ b/src/main/java/com/programmers/heycake/domain/order/service/OrderService.java
@@ -14,9 +14,9 @@ import com.programmers.heycake.common.exception.ErrorCode;
 import com.programmers.heycake.common.mapper.OrderMapper;
 import com.programmers.heycake.domain.order.model.dto.request.MyOrderRequest;
 import com.programmers.heycake.domain.order.model.dto.request.OrderCreateRequest;
-import com.programmers.heycake.domain.order.model.dto.response.OrderGetDetailServiceResponse;
 import com.programmers.heycake.domain.order.model.dto.response.MyOrderResponse;
 import com.programmers.heycake.domain.order.model.dto.response.MyOrderResponseList;
+import com.programmers.heycake.domain.order.model.dto.response.OrderGetDetailServiceResponse;
 import com.programmers.heycake.domain.order.model.entity.CakeInfo;
 import com.programmers.heycake.domain.order.model.entity.Order;
 import com.programmers.heycake.domain.order.model.vo.OrderStatus;
@@ -34,6 +34,7 @@ public class OrderService {
 	@Transactional
 	public void updateOrderState(Long orderId, OrderStatus orderStatus) {
 		isAuthor(orderId);
+		isNew(orderId);
 		getOrder(orderId).upDateOrderStatus(orderStatus);
 	}
 
@@ -83,6 +84,12 @@ public class OrderService {
 	private void isAuthor(Long orderId) {
 		if (getOrder(orderId).isAuthor(getMemberId())) {
 			throw new BusinessException(ErrorCode.FORBIDDEN);
+		}
+	}
+
+	private void isNew(Long orderId) {
+		if (getOrder(orderId).isClosed()) {
+			throw new BusinessException(ErrorCode.DUPLICATED);
 		}
 	}
 }


### PR DESCRIPTION
<!-- 제목 -->
<!-- prefix: 제목 -->

<!-- 내용 -->

### 🐕 작업 개요

- #50 
- #51 
<!--
- [issue 번호1]
- [issue 번호2]
-->

### ⚒️ 작업 사항
- queryDsl 쿼리 작성
- cursor 기반 페이지 네이션
- 회원, 업주 분기 로직
- my order list 반환
<!--
- 자세한 내용 1
- 자세한 내용 2
-->

### 📚 참고 자료
- [커서기반 페이지네이션](https://backend-devcourse.notion.site/343a8a7ec7424c00b9a6b3b5f82ce48d)
<!--
- 레퍼런스 1
- 레퍼런스 2
-->

### 🧐 고민 해줬으면 하는 점
- Dto 네이밍이 조금 고민됩니다..  MyOrderResponseList or MyOrderResponses 중 고민이 됩니다..
- 사진을 하나만 반환해야 하는데 사진 개수만큼 반환됩니다. 이부분은 추후에 수정하겠습니다.
<!-- - 고민포인트 -->