### PR TITLE
Fix: 주문 리스트 조회에서 각각의 주문에 속하는 offerCount 추가, orderStatus 필터링 추가

### DIFF
--- a/src/main/java/com/programmers/heycake/common/mapper/OrderMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/OrderMapper.java
@@ -71,6 +71,7 @@ public class OrderMapper {
 				.orderStatus(order.getOrderStatus())
 				.hopePrice(order.getHopePrice())
 				.region(order.getRegion())
+				.offerCount(order.getOffers().size())
 				.visitDate(order.getVisitDate())
 				.createdAt(order.getCreatedAt())
 				.build();
@@ -92,6 +93,7 @@ public class OrderMapper {
 						.toList()
 				)
 				.region(orderSimpleGetServiceResponse.region())
+				.offerCount(orderSimpleGetServiceResponse.offerCount())
 				.visitTime(orderSimpleGetServiceResponse.visitDate())
 				.createdAt(orderSimpleGetServiceResponse.createdAt())
 				.build();

--- a/src/main/java/com/programmers/heycake/domain/member/model/dto/response/OrderGetDetailResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/member/model/dto/response/OrderGetDetailResponse.java
@@ -15,13 +15,13 @@ public record OrderGetDetailResponse(
 		Long memberId,
 		String title,
 		String region,
-		OrderStatus orderStatus,
-		int hopePrice,
-		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-		LocalDateTime visitDate,
 		CakeInfo cakeInfo,
 		List<String> images,
+		OrderStatus orderStatus,
+		int hopePrice,
 		int offerCount,
+		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+		LocalDateTime visitDate,
 		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 		LocalDateTime createdAt,
 		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/src/main/java/com/programmers/heycake/domain/order/controller/OrderController.java
+++ b/src/main/java/com/programmers/heycake/domain/order/controller/OrderController.java
@@ -49,9 +49,10 @@ public class OrderController {
 			@RequestParam(required = false) Long cursorId,
 			@RequestParam int pageSize,
 			@RequestParam(required = false) CakeCategory cakeCategory,
-			@RequestParam(required = false) String region
+			@RequestParam(required = false) String region,
+			@RequestParam(required = false) String orderStatus
 	) {
-		return ResponseEntity.ok(orderFacade.getOrders(cursorId, pageSize, cakeCategory, region));
+		return ResponseEntity.ok(orderFacade.getOrders(cursorId, pageSize, cakeCategory, region, orderStatus));
 	}
 
 	@GetMapping("/{orderId}")

--- a/src/main/java/com/programmers/heycake/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/order/facade/OrderFacade.java
@@ -59,10 +59,10 @@ public class OrderFacade {
 
 	@Transactional(readOnly = true)
 	public OrderGetSimpleResponses getOrders(
-			Long cursorId, int pageSize, CakeCategory cakeCategory, String region
+			Long cursorId, int pageSize, CakeCategory cakeCategory, String region, String orderStatus
 	) {
 		List<OrderGetServiceSimpleResponse> orderGetSimpleServiceResponses =
-				orderService.getOrders(cursorId, pageSize, cakeCategory, region);
+				orderService.getOrders(cursorId, pageSize, cakeCategory, region, orderStatus);
 
 		List<OrderGetSimpleResponse> orderGetSimpleResponseList =
 				orderGetSimpleServiceResponses

--- a/src/main/java/com/programmers/heycake/domain/order/model/dto/response/OrderGetDetailServiceResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/dto/response/OrderGetDetailServiceResponse.java
@@ -13,11 +13,11 @@ public record OrderGetDetailServiceResponse(
 		Long memberId,
 		String title,
 		String region,
+		CakeInfo cakeInfo,
 		OrderStatus orderStatus,
 		int hopePrice,
-		LocalDateTime visitDate,
-		CakeInfo cakeInfo,
 		int offerCount,
+		LocalDateTime visitDate,
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/programmers/heycake/domain/order/model/dto/response/OrderGetServiceSimpleResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/dto/response/OrderGetServiceSimpleResponse.java
@@ -15,6 +15,7 @@ public record OrderGetServiceSimpleResponse(
 		CakeInfo cakeInfo,
 		OrderStatus orderStatus,
 		int hopePrice,
+		int offerCount,
 		LocalDateTime visitDate,
 		LocalDateTime createdAt
 ) {

--- a/src/main/java/com/programmers/heycake/domain/order/model/dto/response/OrderGetSimpleResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/dto/response/OrderGetSimpleResponse.java
@@ -18,6 +18,7 @@ public record OrderGetSimpleResponse(
 		List<String> images,
 		OrderStatus orderStatus,
 		int hopePrice,
+		int offerCount,
 		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 		LocalDateTime visitTime,
 		@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/src/main/java/com/programmers/heycake/domain/order/repository/OrderQueryDslRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/order/repository/OrderQueryDslRepository.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.heycake.domain.image.model.entity.QImage;
 import com.programmers.heycake.domain.order.model.dto.response.MyOrderResponse;
@@ -58,18 +59,21 @@ public class OrderQueryDslRepository {
 				.fetch();
 	}
 
+	@Transactional
 	public List<Order> findAllByRegionAndCategoryOrderByCreatedAtAsc(
 			Long cursorId,
 			int pageSize,
 			CakeCategory cakeCategory,
-			String region
+			String region,
+			String orderStatus
 	) {
 		return jpaQueryFactory
 				.selectFrom(qOrder)
 				.where(
 						ltOrderId(cursorId),
 						eqRegion(region),
-						eqCakeCategory(cakeCategory)
+						eqCakeCategory(cakeCategory),
+						eqOrderStatus(orderStatus)
 				)
 				.limit(pageSize)
 				.orderBy(qOrder.createdAt.desc())

--- a/src/main/java/com/programmers/heycake/domain/order/service/OrderService.java
+++ b/src/main/java/com/programmers/heycake/domain/order/service/OrderService.java
@@ -73,10 +73,10 @@ public class OrderService {
 	}
 
 	public List<OrderGetServiceSimpleResponse> getOrders(
-			Long cursorId, int pageSize, CakeCategory cakeCategory, String region
+			Long cursorId, int pageSize, CakeCategory cakeCategory, String region, String orderStatus
 	) {
 		return orderQueryDslRepository
-				.findAllByRegionAndCategoryOrderByCreatedAtAsc(cursorId, pageSize, cakeCategory, region)
+				.findAllByRegionAndCategoryOrderByCreatedAtAsc(cursorId, pageSize, cakeCategory, region, orderStatus)
 				.stream()
 				.map(OrderMapper::toOrderGetServiceSimpleResponse)
 				.toList();


### PR DESCRIPTION
### 🐕 작업 개요
- close #150


### ⚒️ 작업 사항
- `OrderGetSimpleResponse`, `OrderGetSimpleServiceResponse` 타입별로 필드 정렬
- `OrderGetDetailResponse`, `OrderGetDetailServiceResponse` 타입별로 필드 정렬
- `OrderGetSimpleResponse`, `OrderGetSimpleServiceResponse` offerCount 필드 추가
- 주문 리스트 조회 OrderStatus 필터링 추가

### 🧐 고민 해줬으면 하는 점
[enum 값 받기](https://github.com/prgrms-web-devcourse/Team-07-hey-cake-BE/pull/151/commits/32ef6a847b25a27ddf32b8876b22e691b703b7e3#r1126003594)
