### PR TITLE
Fix: 오퍼 목록 조회 시 오퍼를 작성한 마켓의 마켓등록id도 응답하도록 변경

### DIFF
--- a/src/main/java/com/programmers/heycake/common/mapper/MarketMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/MarketMapper.java
@@ -25,6 +25,7 @@ public class MarketMapper {
 				.marketName(market.getMarketEnrollment().getMarketName())
 				.businessNumber(market.getMarketEnrollment().getBusinessNumber())
 				.ownerName(market.getMarketEnrollment().getOwnerName())
+				.enrollmentId(market.getMarketEnrollment().getId())
 				.build();
 	}
 

--- a/src/main/java/com/programmers/heycake/common/mapper/OfferMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/OfferMapper.java
@@ -54,6 +54,7 @@ public class OfferMapper {
 		return OfferSummaryResponse.builder()
 				.offerId(offerResponse.offerId())
 				.marketId(offerResponse.marketId())
+				.enrollmentId(marketResponse.enrollmentId())
 				.marketName(marketResponse.marketName())
 				.expectedPrice(offerResponse.expectedPrice())
 				.imageUrl(imageUrl)

--- a/src/main/java/com/programmers/heycake/domain/market/model/dto/response/MarketDetailNoImageResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/market/model/dto/response/MarketDetailNoImageResponse.java
@@ -16,6 +16,7 @@ public record MarketDetailNoImageResponse(
 		String description,
 		String marketName,
 		String businessNumber,
-		String ownerName
+		String ownerName,
+		Long enrollmentId
 ) {
 }

--- a/src/main/java/com/programmers/heycake/domain/offer/controller/OfferController.java
+++ b/src/main/java/com/programmers/heycake/domain/offer/controller/OfferController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.programmers.heycake.domain.offer.facade.OfferFacade;

--- a/src/main/java/com/programmers/heycake/domain/offer/model/dto/response/OfferSummaryResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/offer/model/dto/response/OfferSummaryResponse.java
@@ -3,6 +3,7 @@ package com.programmers.heycake.domain.offer.model.dto.response;
 import lombok.Builder;
 
 @Builder
-public record OfferSummaryResponse(Long offerId, Long marketId, String marketName, int expectedPrice, String imageUrl,
+public record OfferSummaryResponse(Long offerId, Long marketId, Long enrollmentId, String marketName, int expectedPrice,
+																	 String imageUrl,
 																	 String content, int commentCount) {
 }


### PR DESCRIPTION
### 🐕 작업 개요
- closed #152 

### ⚒️ 작업 사항
- 오퍼 목록 조회 시 마켓등록id도 응답에 포함시켰습니다.

### 📚 참고 자료

### 🧐 고민 해줬으면 하는 점