### PR TITLE
Fix: MarketEnrollment 생성 시 예외 처리 추가

### DIFF
--- a/src/main/java/com/programmers/heycake/domain/market/model/entity/MarketEnrollment.java
+++ b/src/main/java/com/programmers/heycake/domain/market/model/entity/MarketEnrollment.java
@@ -100,6 +100,10 @@ public class MarketEnrollment extends BaseEntity {
 		this.enrollmentStatus = EnrollmentStatus.WAITING;
 	}
 
+	public boolean hasOpenDateBeforeNow() {
+		return this.openDate.isBefore(LocalDate.now());
+	}
+
 	public boolean isSameStatus(EnrollmentStatus enrollmentStatus) {
 		return this.enrollmentStatus == enrollmentStatus;
 	}

--- a/src/main/java/com/programmers/heycake/domain/market/service/EnrollmentService.java
+++ b/src/main/java/com/programmers/heycake/domain/market/service/EnrollmentService.java
@@ -41,6 +41,10 @@ public class EnrollmentService {
 
 		MarketEnrollment enrollment = EnrollmentMapper.toEntity(request);
 
+		if (enrollment.hasOpenDateBeforeNow()) {
+			throw new BusinessException(BAD_REQUEST);
+		}
+
 		Member member = memberRepository.findById(getMemberId())
 				.orElseThrow(() -> {
 					throw new BusinessException(UNAUTHORIZED);


### PR DESCRIPTION
- 개업일이 생성 시간 이후인 경우 예외 처리

<!-- 제목 -->
<!-- prefix: 제목 -->

<!-- 내용 -->

### 🐕 작업 개요
- close #201 
<!--
- [issue 번호1]
- [issue 번호2]
-->

### ⚒️ 작업 사항
- 개업일이 생성 시간 이후면 생성 불가능하게 함.
<!--
- 자세한 내용 1
- 자세한 내용 2
-->