### PR TITLE
Chore: 스레드 목록 조회 시 생성일 포맷 변경

### DIFF
--- a/src/main/java/com/programmers/heycake/domain/offer/model/dto/response/OfferSummaryResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/offer/model/dto/response/OfferSummaryResponse.java
@@ -2,10 +2,14 @@ package com.programmers.heycake.domain.offer.model.dto.response;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import lombok.Builder;
 
 @Builder
 public record OfferSummaryResponse(Long offerId, Long marketId, Long enrollmentId, String marketName, int expectedPrice,
-																	 LocalDate createdDate, boolean isPaid, String imageUrl, String content,
+																	 @JsonFormat(pattern = "yyyy.MM.dd") LocalDate createdDate, boolean isPaid,
+																	 String imageUrl,
+																	 String content,
 																	 int commentCount) {
 }


### PR DESCRIPTION
### 🐕 작업 개요
- closed #249 

### ⚒️ 작업 사항
- 스레드 생성일 시간 구분 포맷을 '-' 에서 '.'으로 변경했습니다.

### 📚 참고 자료

### 🧐 고민 해줬으면 하는 점
- https://addio3305.tistory.com/101