### PR TITLE
Hotfix: 내 주문 리스트에서 오퍼 갯수 반환하도록 변경

### DIFF
--- a/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponse.java
@@ -23,4 +23,8 @@ public record MyOrderResponse(
 		String imageUrl,
 		int offerCount
 ) {
+	public MyOrderResponse(Long id, String title, OrderStatus orderStatus, String region, LocalDateTime visitTime,
+			LocalDateTime createdAt, CakeInfo cakeInfo, int hopePrice, String imageUrl) {
+		this(id, title, orderStatus, region, visitTime, createdAt, cakeInfo, hopePrice, imageUrl, 0);
+	}
 }

--- a/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/dto/response/MyOrderResponse.java
@@ -20,6 +20,7 @@ public record MyOrderResponse(
 		LocalDateTime createdAt,
 		CakeInfo cakeInfo,
 		int hopePrice,
-		String imageUrl
+		String imageUrl,
+		int offerCount
 ) {
 }

--- a/src/main/java/com/programmers/heycake/domain/order/repository/OrderQueryDslRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/order/repository/OrderQueryDslRepository.java
@@ -47,7 +47,8 @@ public class OrderQueryDslRepository {
 						qOrder.createdAt,
 						qOrder.cakeInfo,
 						qOrder.hopePrice,
-						qImage.imageUrl
+						qImage.imageUrl,
+						qOrder.offers
 				)
 				.from(qOrder)
 				.leftJoin(qImage)
@@ -74,7 +75,8 @@ public class OrderQueryDslRepository {
 												qOrder.createdAt,
 												qOrder.cakeInfo,
 												qOrder.hopePrice,
-												qImage.imageUrl
+												qImage.imageUrl,
+												qOrder.offers.size()
 										)
 								)
 				);

--- a/src/main/java/com/programmers/heycake/domain/order/service/OrderService.java
+++ b/src/main/java/com/programmers/heycake/domain/order/service/OrderService.java
@@ -118,6 +118,11 @@ public class OrderService {
 		}
 	}
 
+	@Transactional(readOnly = true)
+	public int offerCount(Long orderId) {
+		return getOrder(orderId).getOffers().size();
+	}
+
 	public Order getOrder(Long orderId) {
 		return orderRepository.findById(orderId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));

--- a/src/test/java/com/programmers/heycake/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/programmers/heycake/domain/order/controller/OrderControllerTest.java
@@ -134,6 +134,7 @@ class OrderControllerTest {
 									fieldWithPath("myOrderResponseList[].cakeInfo.requirements").description("요청 사항"),
 									fieldWithPath("myOrderResponseList[].hopePrice").description("희망 가격"),
 									fieldWithPath("myOrderResponseList[].imageUrl").description("이미지 주소"),
+									fieldWithPath("myOrderResponseList[].offerCount").description("오퍼 갯수"),
 									fieldWithPath("cursorId").description("커서 식별자")
 							)));
 		}


### PR DESCRIPTION
<!-- 제목 -->
<!-- prefix: 제목 -->

<!-- 내용 -->

### 🐕 작업 개요
- close #261 
<!--
- [issue 번호1]
- [issue 번호2]
-->

### ⚒️ 작업 사항
- 응답 객체에 offer count 반환하도록 변경

<!--
- 자세한 내용 1
- 자세한 내용 2
-->


<!--
- 레퍼런스 1
- 레퍼런스 2
-->

### 🧐 고민 해줬으면 하는 점
- 현재 마켓 order list에서 트랜잭션을 나누고 있는데 더 좋은 방법 떠오르면 얘기해주시면 감사하겠습니다.
<!-- - 고민포인트 -->