### PR TITLE
Hotfix : CakeSize 에 ETC 옵션 추가

### DIFF
--- a/src/main/java/com/programmers/heycake/domain/order/model/vo/CakeSize.java
+++ b/src/main/java/com/programmers/heycake/domain/order/model/vo/CakeSize.java
@@ -3,5 +3,6 @@ package com.programmers.heycake.domain.order.model.vo;
 public enum CakeSize {
 	MINI,
 	NO_1,
-	NO_2
+	NO_2,
+	ETC
 }


### PR DESCRIPTION
## 🐕 작업 개요
- closed #264 

### ⚒️ 작업 사항
- `CakeInfo`의 `CakeSize` Enum에 `ETC` 옵션을 추가했습니다.
- 프론트엔드 배포 버전에 주문 생성 요청의 `CakeSize`에 `ETC`가 있기 때문입니다.

### 📚 참고 자료

### 🧐 고민 해줬으면 하는 점
