### PR TITLE
Feat: 오퍼, 댓글 조회에 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,10 @@ dependencies {
     //sentry
     implementation 'io.sentry:sentry-spring-boot-starter:6.15.0'
     compile 'io.sentry:sentry-logback:1.7.23'
+
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 asciidoctor {

--- a/src/main/java/com/programmers/heycake/common/cache/CacheConst.java
+++ b/src/main/java/com/programmers/heycake/common/cache/CacheConst.java
@@ -1,0 +1,12 @@
+package com.programmers.heycake.common.cache;
+
+import java.time.Duration;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CacheConst {
+	public static final int MAXIMUM_SIZE = 10000;
+	public static final Duration EXPIRE_MINUTES = Duration.ofMinutes(10);
+}

--- a/src/main/java/com/programmers/heycake/common/cache/CacheType.java
+++ b/src/main/java/com/programmers/heycake/common/cache/CacheType.java
@@ -1,0 +1,21 @@
+package com.programmers.heycake.common.cache;
+
+import java.time.Duration;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheType {
+	OFFERS("offers"),
+	COMMENTS("comments");
+
+	private String name;
+	private Duration expireAfterWrite;
+	private int maximumSize;
+
+	CacheType(String name) {
+		this.name = name;
+		this.expireAfterWrite = CacheConst.EXPIRE_MINUTES;
+		this.maximumSize = CacheConst.MAXIMUM_SIZE;
+	}
+}

--- a/src/main/java/com/programmers/heycake/common/config/CacheConfig.java
+++ b/src/main/java/com/programmers/heycake/common/config/CacheConfig.java
@@ -1,0 +1,38 @@
+package com.programmers.heycake.common.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.programmers.heycake.common.cache.CacheType;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public CacheManager cacheManager() {
+		List<CaffeineCache> caffeineCaches = Arrays.stream(CacheType.values())
+				.map(cache -> new CaffeineCache(
+						cache.getName(),
+						Caffeine.newBuilder()
+								.expireAfterWrite(cache.getExpireAfterWrite())
+								.maximumSize(cache.getMaximumSize())
+								.recordStats()
+								.build()
+				))
+				.toList();
+
+		SimpleCacheManager cacheManager = new SimpleCacheManager();
+		cacheManager.setCaches(caffeineCaches);
+
+		return cacheManager;
+	}
+}

--- a/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
@@ -2,6 +2,8 @@ package com.programmers.heycake.domain.comment.facade;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +38,7 @@ public class CommentFacade {
 	private final OfferService offerService;
 	private final ImageService imageService;
 
+	@CacheEvict(cacheNames = "comments", allEntries = true)
 	@Transactional
 	public void deleteComment(Long commentId) {
 		List<ImageResponse> commentImageResponse = imageService.getImages(commentId, ImageType.COMMENT).images();
@@ -56,6 +59,7 @@ public class CommentFacade {
 		commentService.deleteCommentWithoutAuth(commentId);
 	}
 
+	@CacheEvict(cacheNames = "comments", key = "#commentCreateRequest.offerId")
 	@Transactional
 	public Long createComment(CommentCreateRequest commentCreateRequest) {
 		Long memberId = AuthenticationUtil.getMemberId();
@@ -83,6 +87,7 @@ public class CommentFacade {
 		return createdCommentId;
 	}
 
+	@Cacheable(cacheNames = "comments", key = "#offerId")
 	@Transactional(readOnly = true)
 	public List<CommentsResponse> getComments(Long offerId) {
 		List<Comment> comments = commentService.getCommentsByOfferId(offerId);

--- a/src/main/java/com/programmers/heycake/domain/facade/OfferFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/facade/OfferFacade.java
@@ -5,6 +5,8 @@ import static com.programmers.heycake.domain.image.model.vo.ImageType.*;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,6 +46,7 @@ public class OfferFacade {
 	private final HistoryService historyService;
 	private final ImageService imageService;
 
+	@CacheEvict(cacheNames = "offers", key = "#offerCreateRequest.orderId")
 	@Transactional
 	public Long createOffer(OfferCreateRequest offerCreateRequest) {
 		Order order = orderService.getOrderById(offerCreateRequest.orderId());
@@ -67,6 +70,7 @@ public class OfferFacade {
 		return createdOfferId;
 	}
 
+	@CacheEvict(cacheNames = "offers", allEntries = true)
 	@Transactional
 	public void deleteOffer(Long offerId) {
 		Long marketId = marketService.getMarketIdByMember(memberService.getMemberById(getMemberId()));
@@ -88,6 +92,7 @@ public class OfferFacade {
 		offerService.deleteOfferWithoutAuth(offerId);
 	}
 
+	@Cacheable(cacheNames = "offers", key = "#orderId")
 	@Transactional(readOnly = true)
 	public List<OffersResponse> getOffers(Long orderId) {
 		validateOrderExistsByOrderId(orderId);


### PR DESCRIPTION
### 🐕 작업 개요
- closed #283 

### ⚒️ 작업 사항
- Spring Cache, Caffeine Cache 의존성 추가
- 오퍼 목록 조회, 댓글 목록 조회에 캐시 적용

### 📚 참고 자료
- [캐시 문서화](https://boggy-crowd-a07.notion.site/4b79b539ee134e9fb42744f99f8453a8)

### 🧐 고민 해줬으면 하는 점

<!-- - 고민포인트 -->