### PR TITLE
Feat: 대댓글 기능 구현

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -4,7 +4,7 @@ create table if not exists image
     image_type   varchar(20)   not null,
     image_url    varchar(2000) not null,
     reference_id bigint        not null
-    );
+);
 
 create table if not exists member
 (
@@ -17,7 +17,7 @@ create table if not exists member
     member_authority varchar(255) not null,
     nickname         varchar(30)  not null,
     constraint member_email_uk unique (email)
-    );
+);
 
 drop table if exists market_enrollment;
 
@@ -42,7 +42,7 @@ create table if not exists market_enrollment
     member_id         bigint       not null,
     constraint business_number_uk unique (business_number),
     constraint market_enrollment_with_member_id_fk foreign key (member_id) references member (id)
-    );
+);
 
 create table if not exists market
 (
@@ -61,7 +61,7 @@ create table if not exists market
     member_id            bigint       not null,
     constraint market_with_member_id_fk foreign key (member_id) references member (id),
     constraint market_with_market_enrollment_id_fk foreign key (market_enrollment_id) references market_enrollment (id)
-    );
+);
 
 create table if not exists orders
 (
@@ -81,7 +81,7 @@ create table if not exists orders
     region        varchar(40)  not null,
     title         varchar(20)  not null,
     visit_date    datetime(6)  not null
-    );
+);
 
 create table if not exists offer
 (
@@ -94,19 +94,21 @@ create table if not exists offer
     market_id      bigint       not null,
     order_id       bigint       not null,
     constraint offer_with_order_id_fk foreign key (order_id) references orders (id)
-    );
+);
 
 create table if not exists comment
 (
-    id         bigint auto_increment primary key,
-    created_at datetime(6)  not null,
-    deleted_at datetime(6)  null,
-    updated_at datetime(6)  not null,
-    content    varchar(500) not null,
-    member_id  bigint       not null,
-    offer_id   bigint       not null,
+    id                bigint auto_increment primary key,
+    created_at        datetime(6)  not null,
+    deleted_at        datetime(6)  null,
+    updated_at        datetime(6)  not null,
+    content           varchar(500) not null,
+    member_id         bigint       not null,
+    offer_id          bigint       not null,
+    depth             int          not null,
+    parent_comment_id bigint       null,
     constraint comment_with_offer_id_fk foreign key (offer_id) references offer (id)
-    );
+);
 
 create table if not exists order_history
 (
@@ -118,7 +120,7 @@ create table if not exists order_history
     member_id  bigint      not null,
     order_id   bigint      not null,
     constraint order_history_with_order_id_fk foreign key (order_id) references orders (id)
-    );
+);
 
 create table if not exists token
 (
@@ -127,4 +129,4 @@ create table if not exists token
     refresh_token varchar(300) not null,
     constraint refresh_token_uk unique (refresh_token),
     constraint member_id_uk unique (member_id)
-    );
+);

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -105,7 +105,6 @@ create table if not exists comment
     content           varchar(500) not null,
     member_id         bigint       not null,
     offer_id          bigint       not null,
-    depth             int          not null,
     parent_comment_id bigint       null,
     constraint comment_with_offer_id_fk foreign key (offer_id) references offer (id)
 );

--- a/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
@@ -32,7 +32,8 @@ public class CommentMapper {
 	public static CommentsResponse toCommentsResponse(
 			Comment comment,
 			Member member,
-			ImageResponses imageResponse
+			ImageResponses imageResponse,
+			int childCommentCount
 	) {
 		List<String> imageUrls = imageResponse.images().stream()
 				.map(ImageResponse::imageUrl)
@@ -50,6 +51,7 @@ public class CommentMapper {
 				.createdAt(comment.getCreatedAt())
 				.nickname(member.getNickname())
 				.image(imageUrl)
+				.childCommentCount(childCommentCount)
 				.build();
 	}
 }

--- a/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
@@ -2,6 +2,7 @@ package com.programmers.heycake.common.mapper;
 
 import java.util.List;
 
+import com.programmers.heycake.domain.comment.model.dto.response.ChildCommentsResponse;
 import com.programmers.heycake.domain.comment.model.dto.response.CommentResponse;
 import com.programmers.heycake.domain.comment.model.dto.response.CommentsResponse;
 import com.programmers.heycake.domain.comment.model.entity.Comment;
@@ -52,6 +53,30 @@ public class CommentMapper {
 				.nickname(member.getNickname())
 				.image(imageUrl)
 				.childCommentCount(childCommentCount)
+				.build();
+	}
+
+	public static ChildCommentsResponse toChildCommentResponse(
+			Comment comment,
+			Member member,
+			ImageResponses imageResponses
+	) {
+		List<String> imageUrls = imageResponses.images().stream()
+				.map(ImageResponse::imageUrl)
+				.toList();
+
+		String imageUrl = imageUrls
+				.stream()
+				.findAny()
+				.orElse(null);
+
+		return ChildCommentsResponse.builder()
+				.commentId(comment.getId())
+				.comment(comment.getContent())
+				.memberId(comment.getMemberId())
+				.createdAt(comment.getCreatedAt())
+				.nickname(member.getNickname())
+				.image(imageUrl)
 				.build();
 	}
 }

--- a/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
@@ -15,8 +15,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentMapper {
 
-	public static Comment toEntity(Long memberId, String content) {
-		return new Comment(memberId, content);
+	public static Comment toEntity(Long memberId, String content, int depth, Long parentCommentId) {
+		return new Comment(memberId, content, depth, parentCommentId);
 	}
 
 	public static CommentResponse toCommentResponse(Comment comment) {

--- a/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
@@ -16,8 +16,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentMapper {
 
-	public static Comment toEntity(Long memberId, String content, int depth, Long parentCommentId) {
-		return new Comment(memberId, content, depth, parentCommentId);
+	public static Comment toEntity(Long memberId, String content, Long parentCommentId) {
+		return new Comment(memberId, content, parentCommentId);
 	}
 
 	public static CommentResponse toCommentResponse(Comment comment) {

--- a/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
+++ b/src/main/java/com/programmers/heycake/common/mapper/CommentMapper.java
@@ -53,6 +53,7 @@ public class CommentMapper {
 				.nickname(member.getNickname())
 				.image(imageUrl)
 				.childCommentCount(childCommentCount)
+				.isDeleted(comment.isDeleted())
 				.build();
 	}
 
@@ -77,6 +78,7 @@ public class CommentMapper {
 				.createdAt(comment.getCreatedAt())
 				.nickname(member.getNickname())
 				.image(imageUrl)
+				.isDeleted(comment.isDeleted())
 				.build();
 	}
 }

--- a/src/main/java/com/programmers/heycake/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/controller/CommentController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.programmers.heycake.domain.comment.facade.CommentFacade;
 import com.programmers.heycake.domain.comment.model.dto.request.CommentCreateRequest;
+import com.programmers.heycake.domain.comment.model.dto.response.ChildCommentsResponse;
 import com.programmers.heycake.domain.comment.model.dto.response.CommentsResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -52,5 +53,12 @@ public class CommentController {
 		List<CommentsResponse> comments = commentFacade.getComments(offerId);
 
 		return ResponseEntity.ok(comments);
+	}
+
+	@GetMapping("/{commentId}")
+	public ResponseEntity<List<ChildCommentsResponse>> getChildComments(@PathVariable Long commentId) {
+		List<ChildCommentsResponse> childComments = commentFacade.getChildComments(commentId);
+
+		return ResponseEntity.ok(childComments);
 	}
 }

--- a/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
@@ -70,6 +70,8 @@ public class CommentFacade {
 
 		Long createdCommentId = commentService.createComment(
 				commentCreateRequest.content(),
+				commentCreateRequest.depth(),
+				commentCreateRequest.parentCommentId(),
 				offer,
 				market,
 				member

--- a/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
@@ -71,7 +71,6 @@ public class CommentFacade {
 
 		Long createdCommentId = commentService.createComment(
 				commentCreateRequest.content(),
-				commentCreateRequest.depth(),
 				commentCreateRequest.parentCommentId(),
 				offer,
 				market,

--- a/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.programmers.heycake.common.mapper.CommentMapper;
 import com.programmers.heycake.common.util.AuthenticationUtil;
 import com.programmers.heycake.domain.comment.model.dto.request.CommentCreateRequest;
+import com.programmers.heycake.domain.comment.model.dto.response.ChildCommentsResponse;
 import com.programmers.heycake.domain.comment.model.dto.response.CommentsResponse;
 import com.programmers.heycake.domain.comment.model.entity.Comment;
 import com.programmers.heycake.domain.comment.service.CommentService;
@@ -98,8 +99,21 @@ public class CommentFacade {
 						comment -> {
 							Member member = memberService.getMemberById(comment.getMemberId());
 							int numberOfChildComment = commentService.countChildComment(comment.getId());
-							ImageResponses imageResponse = imageService.getImages(comment.getId(), ImageType.COMMENT);
-							return CommentMapper.toCommentsResponse(comment, member, imageResponse, numberOfChildComment);
+							ImageResponses imageResponses = imageService.getImages(comment.getId(), ImageType.COMMENT);
+							return CommentMapper.toCommentsResponse(comment, member, imageResponses, numberOfChildComment);
+						}
+				).toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<ChildCommentsResponse> getChildComments(Long commentId) {
+		List<Comment> childComments = commentService.getChildCommentsById(commentId);
+		return childComments.stream()
+				.map(
+						comment -> {
+							Member member = memberService.getMemberById(comment.getMemberId());
+							ImageResponses imageResponses = imageService.getImages(comment.getId(), ImageType.COMMENT);
+							return CommentMapper.toChildCommentResponse(comment, member, imageResponses);
 						}
 				).toList();
 	}

--- a/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
@@ -93,7 +93,7 @@ public class CommentFacade {
 	@Cacheable(cacheNames = "comments", key = "#offerId")
 	@Transactional(readOnly = true)
 	public List<CommentsResponse> getComments(Long offerId) {
-		List<Comment> comments = commentService.getCommentsByOfferId(offerId);
+		List<Comment> comments = commentService.getParentCommentsByOfferId(offerId);
 		return comments.stream()
 				.map(
 						comment -> {

--- a/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/facade/CommentFacade.java
@@ -97,8 +97,9 @@ public class CommentFacade {
 				.map(
 						comment -> {
 							Member member = memberService.getMemberById(comment.getMemberId());
+							int numberOfChildComment = commentService.countChildComment(comment.getId());
 							ImageResponses imageResponse = imageService.getImages(comment.getId(), ImageType.COMMENT);
-							return CommentMapper.toCommentsResponse(comment, member, imageResponse);
+							return CommentMapper.toCommentsResponse(comment, member, imageResponse, numberOfChildComment);
 						}
 				).toList();
 	}

--- a/src/main/java/com/programmers/heycake/domain/comment/model/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/model/dto/request/CommentCreateRequest.java
@@ -16,7 +16,6 @@ public record CommentCreateRequest(
 		@NotBlank
 		String content,
 		MultipartFile image,
-		int depth,
 		@Positive
 		@Nullable
 		Long parentCommentId

--- a/src/main/java/com/programmers/heycake/domain/comment/model/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/model/dto/request/CommentCreateRequest.java
@@ -5,6 +5,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 
 import org.hibernate.validator.constraints.Length;
+import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 
 public record CommentCreateRequest(
@@ -14,7 +15,11 @@ public record CommentCreateRequest(
 		@Length(max = 500)
 		@NotBlank
 		String content,
-		MultipartFile image
+		MultipartFile image,
+		int depth,
+		@Positive
+		@Nullable
+		Long parentCommentId
 ) {
 	public boolean existsImage() {
 		return this.image != null;

--- a/src/main/java/com/programmers/heycake/domain/comment/model/dto/response/ChildCommentsResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/model/dto/response/ChildCommentsResponse.java
@@ -1,0 +1,16 @@
+package com.programmers.heycake.domain.comment.model.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+@Builder
+public record ChildCommentsResponse(
+		Long commentId,
+		String comment,
+		String image,
+		Long memberId,
+		String nickname,
+		LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/programmers/heycake/domain/comment/model/dto/response/ChildCommentsResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/model/dto/response/ChildCommentsResponse.java
@@ -11,6 +11,7 @@ public record ChildCommentsResponse(
 		String image,
 		Long memberId,
 		String nickname,
-		LocalDateTime createdAt
+		LocalDateTime createdAt,
+		boolean isDeleted
 ) {
 }

--- a/src/main/java/com/programmers/heycake/domain/comment/model/dto/response/CommentsResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/model/dto/response/CommentsResponse.java
@@ -11,6 +11,7 @@ public record CommentsResponse(
 		String image,
 		Long memberId,
 		String nickname,
-		LocalDateTime createdAt
+		LocalDateTime createdAt,
+		int childCommentCount
 ) {
 }

--- a/src/main/java/com/programmers/heycake/domain/comment/model/dto/response/CommentsResponse.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/model/dto/response/CommentsResponse.java
@@ -12,6 +12,7 @@ public record CommentsResponse(
 		Long memberId,
 		String nickname,
 		LocalDateTime createdAt,
-		int childCommentCount
+		int childCommentCount,
+		boolean isDeleted
 ) {
 }

--- a/src/main/java/com/programmers/heycake/domain/comment/model/entity/Comment.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/model/entity/Comment.java
@@ -38,9 +38,6 @@ public class Comment extends BaseEntity {
 	@Column(name = "content", length = 500, nullable = false)
 	private String content;
 
-	@Column(name = "depth", nullable = false)
-	private int depth;
-
 	@Column(name = "parent_comment_id", nullable = true)
 	private Long parentCommentId;
 
@@ -48,10 +45,9 @@ public class Comment extends BaseEntity {
 	@JoinColumn(name = "offer_id")
 	private Offer offer;
 
-	public Comment(Long memberId, String content, int depth, Long parentCommentId) {
+	public Comment(Long memberId, String content, Long parentCommentId) {
 		this.memberId = memberId;
 		this.content = content;
-		this.depth = depth;
 		this.parentCommentId = parentCommentId;
 	}
 

--- a/src/main/java/com/programmers/heycake/domain/comment/model/entity/Comment.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/model/entity/Comment.java
@@ -13,7 +13,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import com.programmers.heycake.domain.BaseEntity;
 import com.programmers.heycake.domain.offer.model.entity.Offer;
@@ -26,7 +25,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Where(clause = "deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE comment SET deleted_at = NOW() WHERE id = ?")
 public class Comment extends BaseEntity {
 
@@ -67,5 +65,9 @@ public class Comment extends BaseEntity {
 
 	public boolean isNotWrittenBy(Long targetMemberId) {
 		return !Objects.equals(this.memberId, targetMemberId);
+	}
+
+	public boolean isDeleted() {
+		return this.getDeletedAt() != null;
 	}
 }

--- a/src/main/java/com/programmers/heycake/domain/comment/model/entity/Comment.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/model/entity/Comment.java
@@ -40,13 +40,21 @@ public class Comment extends BaseEntity {
 	@Column(name = "content", length = 500, nullable = false)
 	private String content;
 
+	@Column(name = "depth", nullable = false)
+	private int depth;
+
+	@Column(name = "parent_comment_id", nullable = true)
+	private Long parentCommentId;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "offer_id")
 	private Offer offer;
 
-	public Comment(Long memberId, String content) {
+	public Comment(Long memberId, String content, int depth, Long parentCommentId) {
 		this.memberId = memberId;
 		this.content = content;
+		this.depth = depth;
+		this.parentCommentId = parentCommentId;
 	}
 
 	public void setOffer(Offer offer) {

--- a/src/main/java/com/programmers/heycake/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/repository/CommentRepository.java
@@ -12,4 +12,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 	List<Comment> findAllByOfferId(Long offerId);
 
 	int countByOffer(Offer offer);
+
+	int countByParentCommentId(Long parentCommentId);
 }

--- a/src/main/java/com/programmers/heycake/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/repository/CommentRepository.java
@@ -11,6 +11,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	List<Comment> findAllByOfferId(Long offerId);
 
+	List<Comment> findAllByParentCommentId(Long parentCommentId);
+
 	int countByOffer(Offer offer);
 
 	int countByParentCommentId(Long parentCommentId);

--- a/src/main/java/com/programmers/heycake/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/repository/CommentRepository.java
@@ -9,7 +9,7 @@ import com.programmers.heycake.domain.offer.model.entity.Offer;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-	List<Comment> findAllByOfferId(Long offerId);
+	List<Comment> findAllByOfferIdAndDepth(Long offerId, int depth);
 
 	List<Comment> findAllByParentCommentId(Long parentCommentId);
 

--- a/src/main/java/com/programmers/heycake/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/repository/CommentRepository.java
@@ -9,7 +9,7 @@ import com.programmers.heycake.domain.offer.model.entity.Offer;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-	List<Comment> findAllByOfferIdAndDepth(Long offerId, int depth);
+	List<Comment> findAllByOfferIdAndParentCommentIdIsNull(Long offerId);
 
 	List<Comment> findAllByParentCommentId(Long parentCommentId);
 

--- a/src/main/java/com/programmers/heycake/domain/comment/service/CommentService.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/service/CommentService.java
@@ -22,13 +22,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CommentService {
 
-	private static final int PARENT_COMMENT_DEPTH = 0;
-
 	private final CommentRepository commentRepository;
 
 	public Long createComment(
 			String content,
-			int depth,
 			Long parentCommentId,
 			Offer offer,
 			Market market,
@@ -42,7 +39,7 @@ public class CommentService {
 			verifyCommentParentExists(parentCommentId);
 		}
 
-		Comment comment = toEntity(member.getId(), content, depth, parentCommentId);
+		Comment comment = toEntity(member.getId(), content, parentCommentId);
 
 		comment.setOffer(offer);
 
@@ -95,7 +92,7 @@ public class CommentService {
 	}
 
 	public List<Comment> getParentCommentsByOfferId(Long offerId) {
-		return commentRepository.findAllByOfferIdAndDepth(offerId, PARENT_COMMENT_DEPTH);
+		return commentRepository.findAllByOfferIdAndParentCommentIdIsNull(offerId);
 	}
 
 	public List<Comment> getChildCommentsById(Long parentCommentId) {

--- a/src/main/java/com/programmers/heycake/domain/comment/service/CommentService.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/service/CommentService.java
@@ -96,6 +96,10 @@ public class CommentService {
 		return commentRepository.findAllByOfferId(offerId);
 	}
 
+	public List<Comment> getChildCommentsById(Long parentCommentId) {
+		return commentRepository.findAllByParentCommentId(parentCommentId);
+	}
+
 	public int countCommentsByOffer(Offer offer) {
 		return commentRepository.countByOffer(offer);
 	}

--- a/src/main/java/com/programmers/heycake/domain/comment/service/CommentService.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/service/CommentService.java
@@ -99,4 +99,8 @@ public class CommentService {
 	public int countCommentsByOffer(Offer offer) {
 		return commentRepository.countByOffer(offer);
 	}
+
+	public int countChildComment(Long parentCommentId) {
+		return commentRepository.countByParentCommentId(parentCommentId);
+	}
 }

--- a/src/main/java/com/programmers/heycake/domain/comment/service/CommentService.java
+++ b/src/main/java/com/programmers/heycake/domain/comment/service/CommentService.java
@@ -22,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CommentService {
 
+	private static final int PARENT_COMMENT_DEPTH = 0;
+
 	private final CommentRepository commentRepository;
 
 	public Long createComment(
@@ -92,8 +94,8 @@ public class CommentService {
 				.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
 	}
 
-	public List<Comment> getCommentsByOfferId(Long offerId) {
-		return commentRepository.findAllByOfferId(offerId);
+	public List<Comment> getParentCommentsByOfferId(Long offerId) {
+		return commentRepository.findAllByOfferIdAndDepth(offerId, PARENT_COMMENT_DEPTH);
 	}
 
 	public List<Comment> getChildCommentsById(Long parentCommentId) {

--- a/src/test/java/com/programmers/heycake/common/util/TestUtils.java
+++ b/src/test/java/com/programmers/heycake/common/util/TestUtils.java
@@ -210,7 +210,7 @@ public class TestUtils {
 	}
 
 	public static Comment getComment(Long memberId, Offer offer) {
-		Comment comment = new Comment(memberId, "comment");
+		Comment comment = new Comment(memberId, "comment", 0, null);
 		comment.setOffer(offer);
 
 		return comment;

--- a/src/test/java/com/programmers/heycake/common/util/TestUtils.java
+++ b/src/test/java/com/programmers/heycake/common/util/TestUtils.java
@@ -210,7 +210,7 @@ public class TestUtils {
 	}
 
 	public static Comment getComment(Long memberId, Offer offer) {
-		Comment comment = new Comment(memberId, "comment", 0, null);
+		Comment comment = new Comment(memberId, "comment", null);
 		comment.setOffer(offer);
 
 		return comment;


### PR DESCRIPTION
### 🐕 작업 개요
- closed #292 

### ⚒️ 작업 사항
- 대댓글 기능 구현
- 댓글 삭제 시에도 클라이언트에게 응답하도록 구현
  - 삭제된 댓글은 `[삭제된 댓글입니다.]` 라고 표기하기 위함
- 댓글 엔티티에 `depth`, `parentCommentId` 컬럼 추가
  - `depth` : 댓글인지 대댓글인지 (`0` : 댓글, `1`: 대댓글)
  - `parentCommentId` : 대댓글인 경우 부모 댓글 id
- 대댓글 목록 조회 기능을 따로 구현했습니다.
  - 댓글 아래 `대댓글 보기` 버튼을 누르면 대댓글이 보이도록 구현하기 위함 

### 📚 참고 자료

### 🧐 고민 해줬으면 하는 점
- 머지되면 db에 추가된 컬럼 직접 추가하겠습니다.