### PR TITLE
Test: 테스트 환경에서 clearContext() 메서드 사용하지 않도록 변경

### DIFF
--- a/src/test/java/com/programmers/heycake/domain/market/controller/EnrollmentControllerTest.java
+++ b/src/test/java/com/programmers/heycake/domain/market/controller/EnrollmentControllerTest.java
@@ -644,7 +644,6 @@ class EnrollmentControllerTest {
 		@DisplayName("Fail - 회원 인증에 실패하여 401 응답으로 실패한다")
 		void changeEnrollmentStatusFailByUnauthorized() throws Exception {
 			// given
-			// SecurityContextHolder.clearContext();
 			EnrollmentUpdateStatusRequest approvedRequest = new EnrollmentUpdateStatusRequest(APPROVED);
 
 			// when & then
@@ -671,7 +670,6 @@ class EnrollmentControllerTest {
 		@DisplayName("Fail - 관리자가 아닌 회원이 요청하면 403 응답으로 실패한다")
 		void changeEnrollmentStatusFailByForbidden() throws Exception {
 			// given
-			// SecurityContextHolder.clearContext();
 			TestUtils.setContext(user.getId(), USER);
 			EnrollmentUpdateStatusRequest approvedRequest = new EnrollmentUpdateStatusRequest(APPROVED);
 


### PR DESCRIPTION
### 🐕 작업 개요
- close #309  

### ⚒️ 작업 사항
- Redis 에 저장하게 되면, clearContext() 메소드로 저장된 SecurityContext 를 제거할 수 없게 되기 때문에 clearContext() 메서드를 사용하지 않고 테스트를 작성하도록 수정하였습니다.